### PR TITLE
Fix linking issues on the Contributing page.

### DIFF
--- a/docs/content/docs/contributing/index.mdx
+++ b/docs/content/docs/contributing/index.mdx
@@ -13,16 +13,16 @@ hesitate to ask any questions (even if simple ones).**
 The following guidelines should be used as references, they aren't meant to be fully memorized in one go
 (with time, though, you build intuition), search and learn about the necessary guidelines in your domain:
 
-- **[API Docs Guidelines](/contributing/api_docs_guidelines)** Explains ChronoGrapher's API documentation structure, why its rigorous, its goals,
+- **[API Docs Guidelines](/docs/contributing/api_docs_guidelines)** Explains ChronoGrapher's API documentation structure, why its rigorous, its goals,
   when API docs are best fit and when they aren't and special semantic headers used.
 
-- **[AI Use Case Guidelines](/contributing/ai_use_guidelines)** Discusses the use of Generative AI in the contribution process, what is and isn't allowed,
+- **[AI Use Case Guidelines](/docs/contributing/ai_use_guidelines)** Discusses the use of Generative AI in the contribution process, what is and isn't allowed,
   disclosing AI use case in PRs and what punishments may ensue if improper use is noticed.
 
-- **[Guidebook Guidelines](/contributing/guidebook_guidelines)** Teaches how the structure of ChronoGrapher's guidebook,
+- **[Guidebook Guidelines](/docs/contributing/guidebook_guidelines)** Teaches how the structure of ChronoGrapher's guidebook,
   its goals, where the guidebook is best fit and when it isn't and how to use each component.
 
-- **[Tweaking The Website](/contributing/website)** Talks about how ChronoGrapher's website works, the tools it uses,
+- **[Tweaking The Website](/docs/contributing/website)** Talks about how ChronoGrapher's website works, the tools it uses,
   the workplace (explains each folder and file) and how to tweak it.
 
 **Before you take a look in the guidelines**, we should first mention some of the prerequisite


### PR DESCRIPTION
- Added `/docs` at the beginning of the links.

Without the docs, following link is clicked.

<img width="1916" height="911" alt="Screenshot 2026-02-22 003711" src="https://github.com/user-attachments/assets/f4cc9f09-1d40-4baf-90b2-05c35d2aa0ff" />

, and it forwarded to **404** Page.
<img width="351" height="126" alt="Screenshot 2026-02-22 2" src="https://github.com/user-attachments/assets/10604c40-73d2-458a-a704-501971401898" />
