### PR TITLE
Add doc-strings to top-module level entry point for core.

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -65,20 +65,20 @@ pub mod errors; // skipcq: RS-D1001
 /// - **[`DefaultScheduler`](crate::scheduler::DefaultScheduler)** / **[`DefaultSchedulerConfig`](crate::scheduler::DefaultSchedulerConfig)** - Default implementation;
 ///   generic over the error type `E: [`TaskError`](crate::errors::TaskError)`.
 /// - **Feature-gated schedulers**:
-///   - [`DefaultAnyhowScheduler`](crate::scheduler::DefaultAnyhowScheduler) (`anyhow` feature)
-///   - [`DefaultEyreScheduler`](crate::scheduler::DefaultEyreScheduler) (`eyre` feature)
+///   - [`DefaultAnyhowScheduler`] (`anyhow` feature)
+///   - [`DefaultEyreScheduler`] (`eyre` feature)
 ///
 /// Main operations: [`start`](crate::scheduler::Scheduler::start), [`schedule`](crate::scheduler::Scheduler::schedule),
 /// [`cancel`](crate::scheduler::Scheduler::cancel), [`clear`](crate::scheduler::Scheduler::clear), [`abort`](crate::scheduler::Scheduler::abort).
 ///
 /// # Features:
 ///
-/// - `anyhow` - [`DefaultAnyhowScheduler`](crate::scheduler::DefaultAnyhowScheduler)
-/// - `eyre` - [`DefaultEyreScheduler`](crate::scheduler::DefaultEyreScheduler)
+/// - `anyhow` - [`DefaultAnyhowScheduler`]
+/// - `eyre` - [`DefaultEyreScheduler`]
 ///
 /// # Usage:
-/// Build a scheduler with default config, start it, then schedule tasks. Use the [`prelude`](crate::chronographer::prelude) or
-/// [`DefaultScheduler`](crate::chronographer::scheduler::DefaultScheduler) and [`DefaultSchedulerConfig`](crate::chronographer::scheduler::DefaultSchedulerConfig) for the default implementation.
+/// Build a scheduler with default config, start it, then schedule tasks. Use the [`prelude`] or
+/// [`DefaultScheduler`] and [`DefaultSchedulerConfig`] for the default implementation.
 ///
 /// # Example:
 /// ```rust
@@ -96,21 +96,21 @@ pub mod scheduler; // skipcq: RS-D1001
 ///
 /// This module defines the main types used to represent runnable work and when it runs:
 ///
-/// - **[`Task`](crate::task::Task)** — The main type that pairs a [`TaskFrame`](crate::task::TaskFrame) with a [`TaskTrigger`](crate::task::TaskTrigger);
+/// - **[`Task`]** — The main type that pairs a [`TaskFrame`] with a [`TaskTrigger`];
 ///   use [`Task::new`](crate::task::Task::new) or `Default::default()` to construct, and [`Task::as_erased`](crate::task::Task::as_erased) to get an [`ErasedTask`](crate::task::ErasedTask) for the scheduler.
-/// - **[`ErasedTask`](crate::task::ErasedTask)** — Type-erased task used by the scheduler and anywhere you need a single task type regardless of frame/trigger; one of the central types in the crate. Obtained via [`Task::as_erased`](crate::task::Task::as_erased).
-/// - **[`RestrictTaskFrameContext`](crate::task::RestrictTaskFrameContext)** — Context passed into task frames during execution.
-/// - **Hooks** — Observers that react to task and frame events (e.g. [`OnTaskStart`](crate::task::hooks::events::OnTaskStart), [`OnTaskEnd`](crate::task::hooks::events::OnTaskEnd), retry, timeout). Implement [`TaskHook`](crate::task::hooks::TaskHook)`<E>` for an event type `E`: [TaskHookEvent](crate::task::hooks::TaskHookEvent) and attach via [`Task::attach_hook`](crate::task::Task::attach_hook). [`TaskHookEvent`](crate::task::hooks::TaskHookEvent) defines the event and payload; [`TaskHookContext`](crate::task::hooks::TaskHookContext) is passed to handlers; [`TaskHookContainer`](crate::task::hooks::TaskHookContainer) holds hooks on each task.
+/// - **[`ErasedTask`]** — Type-erased task used by the scheduler and anywhere you need a single task type regardless of frame/trigger; one of the central types in the crate. Obtained via [`Task::as_erased`].
+/// - **[`RestrictTaskFrameContext`]** — Context passed into task frames during execution.
+/// - **Hooks** — Observers that react to task and frame events (e.g. [`OnTaskStart`], [`OnTaskEnd`], retry, timeout). Implement [`TaskHook`]<`E`> for an event type `E`: [TaskHookEvent] and attach via [`Task::attach_hook`]. [`TaskHookEvent`] defines the event and payload; [`TaskHookContext`] is passed to handlers; [`TaskHookContainer`] holds hooks on each task.
 ///
-/// The module also re-exports frame and trigger types from its submodules (e.g. [`TaskFrame`](crate::task::TaskFrame), [`TaskTrigger`](crate::task::TaskTrigger), [`TaskFrameBuilder`](crate::task::TaskFrameBuilder), and the concrete frame and schedule types).
+/// The module also re-exports frame and trigger types from its submodules (e.g. [`TaskFrame`], [`TaskTrigger`], [`TaskFrameBuilder`], and the concrete frame and schedule types).
 ///
 /// # Usage
 ///
-/// Build a [`Task`](crate::task::Task) with [`Task::new`](crate::task::Task::new)(trigger, frame), call [`as_erased`](crate::task::Task::as_erased) to get an [`ErasedTask`](crate::task::ErasedTask), then pass that to [`Scheduler::schedule`](crate::chronographer::scheduler::Scheduler::schedule) or run it with [`ErasedTask::run`](crate::task::ErasedTask::run).
+/// Build a [`Task`] with [`Task::new`](trigger, frame), call [`as_erased`] to get an [`ErasedTask`], then pass that to [`Scheduler::schedule`] or run it with [`ErasedTask::run`].
 pub mod task; // skipcq: RS-D1001
 
-/// The `utils` module provides utility types and functions for the core library.
-/// It mainly defines the [`TaskIdentifier`](crate::utils::TaskIdentifier) trait and the [`DefaultTaskID`](crate::utils::DefaultTaskID) type.
+/// The [`utils`] module provides utility types and functions for the core library.
+/// It mainly defines the [`TaskIdentifier`](crate::utils::TaskIdentifier) trait.
 ///
 /// # Usage
 ///

--- a/core/src/scheduler.rs
+++ b/core/src/scheduler.rs
@@ -22,14 +22,68 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use typed_builder::TypedBuilder;
 
+/// The default scheduler type.
+///
+/// # Usage
+/// Use the [`DefaultScheduler`] type as the default implementation of the [`Scheduler`] type.
+/// Use the [`DefaultSchedulerConfig`] type as the default implementation of the [`SchedulerConfig`] type.
+///
+/// # Example
+/// ```rust
+/// use chronographer::prelude::*;
+/// use chronographer::scheduler::DefaultScheduler;
+///
+/// let scheduler = DefaultScheduler::<Box<dyn std::error::Error + Send + Sync>>::default();
+/// scheduler.start().await;
+/// let id = scheduler.schedule(&my_task).await?;
+/// ```
+///
+/// In the example, we use the [`DefaultScheduler`] type as the default implementation of the [`Scheduler`] type.
 pub type DefaultScheduler<E> = Scheduler<DefaultSchedulerConfig<E>>;
 
+/// The default scheduler type with the [`anyhow`](https://docs.rs/anyhow/latest/anyhow/) error type.
+///
+/// # Usage
+/// Use the [`DefaultAnyhowScheduler`] type as the default implementation of the [`Scheduler`] type. The [`anyhow`](https://docs.rs/anyhow/latest/anyhow/) error type is used as the error type for the scheduler allowing users to have ergonomic error propagation.
+///
+/// # Example
+/// ```rust
+/// use chronographer::prelude::*;
+/// use chronographer::scheduler::DefaultAnyhowScheduler;
+///
+/// let scheduler = DefaultAnyhowScheduler::default();
+/// scheduler.start().await;
+/// let id = scheduler.schedule(&my_task).await?;
+/// ```
+///
+/// In the example, we use the [`DefaultAnyhowScheduler`](crate::scheduler::DefaultAnyhowScheduler) type as the default implementation of the [`Scheduler`](crate::scheduler::Scheduler) type.
 #[cfg(feature = "anyhow")]
 pub type DefaultAnyhowScheduler = DefaultScheduler<anyhow::Error>;
 
+/// The default scheduler type with the [`eyre`](https://docs.rs/eyre/latest/eyre/) error type.
+///
+/// # Usage
+/// Use the [`DefaultEyreScheduler`](crate::scheduler::DefaultEyreScheduler) type as the default implementation of the [`Scheduler`](crate::scheduler::Scheduler) type. The [`eyre`](https://docs.rs/eyre/latest/eyre/) error type is used as the error type for the scheduler allowing users to have richer, customizable error reports (often paired with [`color-eyre`](https://docs.rs/color-eyre/latest/color_eyre/) in CLI tooling).
+///
+/// # Example
+/// ```rust
+/// use chronographer::prelude::*;
+/// use chronographer::scheduler::DefaultEyreScheduler;
+///
+/// let scheduler = DefaultEyreScheduler::default();
+/// scheduler.start().await;
+/// let id = scheduler.schedule(&my_task).await?;
+/// ```
+///
+/// In the example, we use the [`DefaultEyreScheduler`](crate::scheduler::DefaultEyreScheduler) type as the default implementation of the [`Scheduler`](crate::scheduler::Scheduler) type.
 #[cfg(feature = "eyre")]
 pub type DefaultEyreScheduler = DefaultScheduler<eyre::Error>;
 
+// TODO: Add more details about the configuration with custom types.
+/// The `SchedulerConfig` trait for configuring the scheduler.
+///
+/// # Usage
+/// Implement the [`SchedulerConfig`] trait to configure the scheduler. The scheduler configures the identifier, error type, clock, store, dispatcher, and engine types.
 pub trait SchedulerConfig: Sized + 'static {
     type TaskIdentifier: TaskIdentifier;
     type TaskError: TaskError;
@@ -39,8 +93,32 @@ pub trait SchedulerConfig: Sized + 'static {
     type SchedulerEngine: SchedulerEngine<Self>;
 }
 
+/// Default implementation of [`SchedulerConfig`], parameterized by the task error type `E`.
+///
+/// This type is used as the config for [`DefaultScheduler`]`<E>` (i.e. `Scheduler<DefaultSchedulerConfig<E>>`).
+/// You do not construct `DefaultSchedulerConfig` values directly; you obtain a scheduler via
+/// [`DefaultScheduler`]`::default()` or [`Scheduler::builder`], which use this config under the hood.
+///
+/// # Type parameters
+/// - `E` - The task error type, must implement [`TaskError`] (and thus
+///   `Debug + Display + Send + Sync + Any`). For example: [`StandardCoreErrorsCG`](crate::errors::StandardCoreErrorsCG),
+///   or with features `anyhow` / `eyre`: `anyhow::Error` / `eyre::Error`. Note: `Box<dyn std::error::Error + Send + Sync>` does *not* implement `TaskError` (it does not implement `Any`).
+///
+/// **The default implementation** uses:
+/// - **[`DefaultTaskID`]** - task identifier
+/// - **[`ProgressiveClock`]** - clock
+/// - **[`EphemeralSchedulerTaskStore`]** - in-memory task store
+/// - **[`DefaultTaskDispatcher`]** - task dispatcher
+/// - **[`DefaultSchedulerEngine`]** - engine
 pub struct DefaultSchedulerConfig<E: TaskError>(PhantomData<E>);
 
+/// The default implementation of the [`SchedulerConfig`] trait.
+///
+/// The default implementation uses the [`DefaultTaskID`] type as the identifier, the [`ProgressiveClock`] type as the clock, the [`EphemeralSchedulerTaskStore`] type as the store, the [`DefaultTaskDispatcher`] type as the dispatcher, and the [`DefaultSchedulerEngine`] type as the engine.
+///
+/// This type is used as the config for [`DefaultScheduler`]`<E>` (i.e. `Scheduler<DefaultSchedulerConfig<E>>`).
+/// You do not construct `DefaultSchedulerConfig` values directly; you obtain a scheduler via
+/// [`DefaultScheduler`]`::default()` or [`Scheduler::builder`], which use this config under the hood.
 impl<E: TaskError> SchedulerConfig for DefaultSchedulerConfig<E> {
     type TaskIdentifier = DefaultTaskID;
     type TaskError = E;
@@ -50,6 +128,11 @@ impl<E: TaskError> SchedulerConfig for DefaultSchedulerConfig<E> {
     type SchedulerEngine = DefaultSchedulerEngine<Self>;
 }
 
+/// The `SchedulerInitConfig` type for the configuration of the scheduler.
+///
+/// # Usage
+/// Use by the [`Scheduler::builder`] method to build a scheduler. The builder method is used to configure the scheduler with the desired types.
+/// As the builder method is used to build a scheduler, you do not construct `SchedulerInitConfig` values directly; you obtain a scheduler via `Scheduler::default()`.
 #[derive(TypedBuilder)]
 #[builder(build_method(into = Scheduler<T>))]
 pub struct SchedulerInitConfig<T: SchedulerConfig> {
@@ -62,6 +145,21 @@ pub struct SchedulerInitConfig<T: SchedulerConfig> {
     engine: T::SchedulerEngine,
 }
 
+/// The `From` trait implementation for the `SchedulerInitConfig` type.
+///
+/// # Usage
+/// Use the [`From`] trait implementation to convert a [`SchedulerInitConfig`] value into a [`Scheduler`] value.
+/// As the builder method is used to build a scheduler, you do not construct `SchedulerInitConfig` values directly; you obtain a scheduler via `Scheduler::default()`.
+///
+/// # Example
+/// Even though you do not construct `SchedulerInitConfig` values directly, you can still convert it into a `Scheduler` value using the `From` trait implementation.
+/// ```rust
+/// use chronographer::prelude::*;
+/// use chronographer::scheduler::SchedulerInitConfig;
+///
+/// let config = SchedulerInitConfig::<Box<dyn std::error::Error + Send + Sync>>::default();
+/// let scheduler = Scheduler::from(config);
+/// ```
 impl<C: SchedulerConfig> From<SchedulerInitConfig<C>> for Scheduler<C> {
     fn from(config: SchedulerInitConfig<C>) -> Self {
         Self {
@@ -75,6 +173,33 @@ impl<C: SchedulerConfig> From<SchedulerInitConfig<C>> for Scheduler<C> {
     }
 }
 
+/// The `Scheduler` type for the scheduler.
+///
+/// # Usage
+/// Use the [`Scheduler`] type to create a scheduler. The scheduler is used to schedule tasks. The scheduler owns a clock, a task store, a task dispatcher, and an engine.
+/// The scheduler can be started, stopped, and scheduled tasks.
+///
+/// # Type parameters
+/// - `C` - The scheduler config type, must implement [`SchedulerConfig`] (and thus
+///   `Sized + 'static`). For example: [`DefaultSchedulerConfig`].
+///
+/// # Fields
+/// - `clock` - The clock of the scheduler.
+/// - `store` - The task store of the scheduler.
+/// - `dispatcher` - The task dispatcher of the scheduler.
+/// - `engine` - The engine of the scheduler.
+/// - `process` - The process of the scheduler.
+/// - `instruction_channel` - The instruction channel of the scheduler.
+///
+/// # Example
+/// ```rust
+/// use chronographer::prelude::*;
+/// use chronographer::scheduler::Scheduler;
+///
+/// let scheduler = Scheduler::<Box<dyn std::error::Error + Send + Sync>>::default();
+/// scheduler.start().await;
+/// let id = scheduler.schedule(&my_task).await?;
+/// ```
 pub struct Scheduler<C: SchedulerConfig> {
     clock: Arc<C::SchedulerClock>,
     store: Arc<C::SchedulerTaskStore>,
@@ -84,6 +209,13 @@ pub struct Scheduler<C: SchedulerConfig> {
     instruction_channel: Mutex<Option<tokio::sync::mpsc::Sender<SchedulerHandlePayload>>>,
 }
 
+/// Implements [`Default`] for [`Scheduler`]`<C>` when the single config type `C` has all of its
+/// associated types implementing [`Default`]: `C::SchedulerTaskStore`, `C::SchedulerClock`,
+/// `C::SchedulerEngine`, and `C::SchedulerTaskDispatcher`. For example: [`DefaultSchedulerConfig`].
+///
+/// The returned scheduler is equivalent to [`Scheduler::builder`] with default store, clock,
+/// engine, and dispatcher for that config. [`DefaultSchedulerConfig`]`<E>` meets these bounds for
+/// any `E: [`TaskError`](crate::errors::TaskError)`, so [`DefaultScheduler`]`<E>` has `Default` in that case.
 impl<C> Default for Scheduler<C>
 where
     C: SchedulerConfig<
@@ -94,6 +226,9 @@ where
             TaskError: TaskError,
         >,
 {
+    /// The default implementation of the [`Default`] trait for the [`Scheduler`] type.
+    ///
+    /// Uses the [`Scheduler::builder`] method to create a scheduler with the default config.
     fn default() -> Self {
         Self::builder()
             .store(C::SchedulerTaskStore::default())
@@ -104,12 +239,46 @@ where
     }
 }
 
+/// The `SchedulerHandle` type for the scheduler handle.
+///
+/// # Usage
+/// Use the [`SchedulerHandle`] type to create a scheduler handle. The scheduler handle is used to instruct the scheduler to reschedule, halt, block, or execute a task.
+///
+/// # Fields
+/// - `id` - The identifier of the task.
+/// - `channel` - The channel of the scheduler handle. The channel is used to send instructions to the scheduler.
+///
+/// # Example
+/// ```rust
+/// use chronographer::prelude::*;
+/// use chronographer::scheduler::SchedulerHandle;
+/// use chronographer::scheduler::SchedulerHandleInstructions;
+///
+/// let scheduler = Scheduler::<Box<dyn std::error::Error + Send + Sync>>::default();
+/// scheduler.start().await;
+/// let id = scheduler.schedule(&my_task).await?;
+/// let handle = SchedulerHandle {
+///     id: Arc::new(id),
+///     channel: scheduler.instruction_channel.lock().await.unwrap().clone(), // get the instruction channel from the scheduler
+/// };
+/// handle.instruct(SchedulerHandleInstructions::Reschedule).await;
+/// ```
 pub(crate) struct SchedulerHandle {
     pub(crate) id: Arc<dyn Any + Send + Sync>,
     pub(crate) channel: tokio::sync::mpsc::Sender<SchedulerHandlePayload>,
 }
 
 impl SchedulerHandle {
+    /// The `instruct` method for the `SchedulerHandle` type.
+    ///
+    /// # Usage
+    /// Use the `instruct` method to instruct the scheduler to reschedule, halt, block, or execute a task. The instruction is sent to the scheduler via the channel.
+    ///
+    /// # Parameters
+    /// - `instruction` - The instruction to send to the scheduler. For example: [`SchedulerHandleInstructions::Reschedule`](crate::scheduler::engine::default::SchedulerHandleInstructions::Reschedule).
+    ///
+    /// # Returns
+    /// - `()` - The result of the instruction.
     pub(crate) async fn instruct(&self, instruction: SchedulerHandleInstructions) {
         self.channel
             .send((self.id.clone(), instruction))


### PR DESCRIPTION
Only defines the prelude and top-level package explanations for now.
- [x] every module inside of core/src/lib.rs (including the prelude one)

Next:
- [ ]  core/src/scheduler (Including its submodules)
- [ ]  core/src/scheduler.rs
- [ ]  core/src/task/hooks.rs
