### PR TITLE
fix: fixed Makefile indenting to make it works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt clippy build test ci
+.PHONY: fmt clippy build test bench ci
 
 fmt:
 	cargo fmt --all -- --check
@@ -10,10 +10,9 @@ build:
 	cargo build --all-features
 
 test:
-	cd tests && cargo test --all-features && cd ..
+	cd tests && cargo test --all-features
 
 bench:
-	cd benches && cargo bench && cd ..
+	cd benches && cargo bench
 
-ci:
-	fmt clippy build test
+ci: fmt clippy build test


### PR DESCRIPTION
The previous Makefile  caused this error that happened in Ci *make ci*:
<img width="1159" height="197" alt="image" src="https://github.com/user-attachments/assets/7ab48d0b-6141-4854-bcd8-0899119a70b7" />

